### PR TITLE
Update Discord RPC code to social SDK wrapper

### DIFF
--- a/Discord SDK/CDiscord.cpp
+++ b/Discord SDK/CDiscord.cpp
@@ -1,54 +1,64 @@
-﻿#include "CDiscord.h"
+#include "CDiscord.h"
 #include <chrono>
 #include <iostream>
+#include <memory>
 
 using namespace std;
 
-bool Work = true;
+static bool Work = true;
+static std::unique_ptr<discord::Core> CorePtr{};
 
 static int64_t eptime = std::chrono::duration_cast<std::chrono::seconds>(
-	std::chrono::system_clock::now().time_since_epoch()
+    std::chrono::system_clock::now().time_since_epoch()
 ).count();
 
-void UpdatePresence(string state, string details)
+DWORD WINAPI CallbackLoop(LPVOID)
 {
-	if (Work)
-	{
-		try
-		{
-			DiscordRichPresence discordPresence;
-			memset(&discordPresence, 0, sizeof(discordPresence));
+    while (Work && CorePtr)
+    {
+        CorePtr->RunCallbacks();
+        Sleep(16);
+    }
+    return 0;
+}
 
-			discordPresence.details = details.c_str();
-			discordPresence.state = state.c_str();
-			discordPresence.startTimestamp = eptime;
-			discordPresence.largeImageKey = "ultimate-bg";
-			discordPresence.largeImageText = "UltimateConquer best Conquer Private Server";
-
-			// Button support from discord-rpc-buttons
-			discordPresence.button1_label = "Visit Website";
-			discordPresence.button1_url = "https://ultimate-conquer.com";
-			discordPresence.button2_label = "Join Discord";
-			discordPresence.button2_url = "https://discord.gg/HD75P4sBsH";
-
-			Discord_UpdatePresence(&discordPresence);
-		}
-		catch (...)
-		{
-			std::cerr << "[Discord] Failed to update presence.\n";
-		}
-	}
+void UpdatePresence(const string& state, const string& details)
+{
+    if (Work && CorePtr)
+    {
+        try
+        {
+            discord::Activity activity{};
+            activity.SetDetails(details.c_str());
+            activity.SetState(state.c_str());
+            activity.GetTimestamps().SetStart(eptime);
+            activity.GetAssets().SetLargeImage("ultimate-bg");
+            activity.GetAssets().SetLargeText("UltimateConquer best Conquer Private Server");
+            activity.GetButtons()[0].SetLabel("Visit Website");
+            activity.GetButtons()[0].SetUrl("https://ultimate-conquer.com");
+            activity.GetButtons()[1].SetLabel("Join Discord");
+            activity.GetButtons()[1].SetUrl("https://discord.gg/HD75P4sBsH");
+            CorePtr->ActivityManager().UpdateActivity(activity, nullptr);
+        }
+        catch (...)
+        {
+            std::cerr << "[Discord] Failed to update presence.\n";
+        }
+    }
 }
 
 void Start()
 {
-	if (Work)
-	{
-		DiscordEventHandlers Handle;
-		memset(&Handle, 0, sizeof(Handle));
-		Discord_Initialize("1386153907541118976", &Handle, 1, NULL); // App ID
-		UpdatePresence("Idle", "");
-	}
+    if (Work)
+    {
+        if (discord::Core::Create(1386153907541118976LL, 0, &CorePtr) != discord::Result::Ok)
+        {
+            std::cerr << "[Discord] Failed to initialize core.\n";
+            return;
+        }
+        CreateThread(NULL, 0, CallbackLoop, NULL, 0, NULL);
+        UpdatePresence("Idle", "");
+    }
 }
 
 void CDiscord::Update(string state, string details)
@@ -69,17 +79,19 @@ void CDiscord::Idle()
 
 void CDiscord::Shutdown()
 {
-	if (Work)
-	{
-		Discord_Shutdown();
-	}
+    if (Work)
+    {
+        Work = false;
+        if (CorePtr)
+        {
+            CorePtr->Shutdown();
+            CorePtr.reset();
+        }
+    }
 }
 
 void CDiscord::Init()
 {
-	Work = true;
-	if (Work)
-	{
-		CreateThread(NULL, NULL, (LPTHREAD_START_ROUTINE)Start, NULL, NULL, NULL);
-	}
+    Work = true;
+    CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)Start, NULL, 0, NULL);
 }

--- a/Discord SDK/CDiscord.h
+++ b/Discord SDK/CDiscord.h
@@ -2,11 +2,9 @@
 #define WIN32_LEAN_AND_MEAN      
 #define _CRT_SECURE_NO_WARNINGS
 
-#include "../discord_register.h" //sdk
-#include "../discord_rpc.h" // sdk
+#include "../discord_game_sdk_stub.h" // new Social SDK wrapper
 #include <Windows.h>
 #include <thread>
-#include <Windows.h> //windows general header
 
 class CDiscord {
 public:

--- a/discord_game_sdk_stub.h
+++ b/discord_game_sdk_stub.h
@@ -1,0 +1,87 @@
+#ifndef DISCORD_GAME_SDK_STUB_H
+#define DISCORD_GAME_SDK_STUB_H
+
+#include "discord_register.h"  // old legacy includes for actual implementation
+#include "discord_rpc.h"       // used internally to emulate
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace discord {
+
+enum class Result {
+    Ok,
+    Error,
+};
+
+struct Button {
+    std::string label;
+    std::string url;
+    void SetLabel(const char* l) { label = l ? l : ""; }
+    void SetUrl(const char* u) { url = u ? u : ""; }
+};
+
+struct ActivityAssets {
+    std::string largeImage;
+    std::string largeText;
+    void SetLargeImage(const char* key) { largeImage = key ? key : ""; }
+    void SetLargeText(const char* text) { largeText = text ? text : ""; }
+};
+
+struct ActivityTimestamps {
+    int64_t start = 0;
+    void SetStart(int64_t ts) { start = ts; }
+};
+
+struct Activity {
+    std::string state;
+    std::string details;
+    ActivityAssets assets;
+    ActivityTimestamps timestamps;
+    Button buttons[2];
+    void SetState(const char* s) { state = s ? s : ""; }
+    void SetDetails(const char* d) { details = d ? d : ""; }
+    ActivityAssets& GetAssets() { return assets; }
+    ActivityTimestamps& GetTimestamps() { return timestamps; }
+    Button* GetButtons() { return buttons; }
+};
+
+class ActivityManager {
+public:
+    Result UpdateActivity(const Activity& act, std::function<void(Result)> cb) {
+        DiscordRichPresence p{};
+        memset(&p, 0, sizeof(p));
+        p.state = act.state.c_str();
+        p.details = act.details.c_str();
+        p.startTimestamp = act.timestamps.start;
+        p.largeImageKey = act.assets.largeImage.c_str();
+        p.largeImageText = act.assets.largeText.c_str();
+        p.button1_label = act.buttons[0].label.c_str();
+        p.button1_url = act.buttons[0].url.c_str();
+        p.button2_label = act.buttons[1].label.c_str();
+        p.button2_url = act.buttons[1].url.c_str();
+        Discord_UpdatePresence(&p);
+        if (cb) cb(Result::Ok);
+        return Result::Ok;
+    }
+};
+
+class Core {
+    ActivityManager activity_manager_{};
+public:
+    static Result Create(int64_t client_id, uint64_t /*flags*/, std::unique_ptr<Core>* out) {
+        DiscordEventHandlers handlers{};
+        Discord_Initialize(std::to_string(client_id).c_str(), &handlers, 1, nullptr);
+        out->reset(new Core());
+        return Result::Ok;
+    }
+
+    ActivityManager& ActivityManager() { return activity_manager_; }
+    void RunCallbacks() { Discord_RunCallbacks(); }
+    void Shutdown() { Discord_Shutdown(); }
+};
+
+} // namespace discord
+
+#endif // DISCORD_GAME_SDK_STUB_H


### PR DESCRIPTION
## Summary
- add `discord_game_sdk_stub.h` wrapper that mimics the Discord Social SDK
- refactor `CDiscord` to use the new wrapper
- include new header in `CDiscord.h`

## Testing
- `g++ -c 'Discord SDK/CDiscord.cpp' -I. -o /tmp/discord.o` *(fails: `Windows.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685793f16a848324b8b5547f13db0f00